### PR TITLE
未認証時にダッシュボードにアクセスした際にnillエラーになる箇所の修正

### DIFF
--- a/api/app/controllers/api/v1/users_controller.rb
+++ b/api/app/controllers/api/v1/users_controller.rb
@@ -1,16 +1,16 @@
 class Api::V1::UsersController < ApplicationController
 
     def show_current_user
-        begin
-          user_data = current_user&.attributes
-          user_data[:icon_url] = rails_blob_url(current_user.icon) if current_user&.icon.attached?
-        rescue ActiveRecord::RecordNotFound
-          return render json: { error: 'ユーザー情報が存在しません' }, status: 404
-        end
-      
-        render json: user_data
+      # NOTE:未認証であれば401エラーを返却する。
+      unless current_user
+        return head :unauthorized
       end
-      
+    
+      user_data = current_user.attributes
+      user_data[:icon_url] = rails_blob_url(current_user.icon) if current_user.icon.attached?
+      render json: user_data
+    end
+    
     def update
         begin
           if current_user.update(user_params)


### PR DESCRIPTION
## [概要]

- 未認証時にダッシュボードにアクセスした際に500エラーとなっていた箇所の修正をしました。
```ruby
      user_data = current_user.attributes
      user_data[:icon_url] = rails_blob_url(current_user.icon) if current_user.icon.attached?
``` 
未認証時は`current_user`がnillとなってしまいnillに対してattached?の処理を実行していたためnillエラーが起こっていました。今回は`current_user`がnillの場合は除外させることによりよりシンプルな処理にして対処しています。


[該当issueチケット](https://github.com/Kenty-725/qiita-kenny/issues/10)
## [挙動動画]
https://github.com/Kenty-725/qiita-kenny/assets/116368383/a1e60c80-3be5-41de-87be-5e1bce65826e