### PR TITLE
記事いいね機能　実装

### DIFF
--- a/api/app/controllers/api/v1/likes_controller.rb
+++ b/api/app/controllers/api/v1/likes_controller.rb
@@ -3,15 +3,21 @@ class Api::V1::LikesController < ApplicationController
     def create
         @like = current_user.likes.build(like_params)
             if  @like.save
-                render json: @like
+                render json: @like, status: :created
             else
-                render json: @like.errors, status: 422
+                render json: @like.errors, status: :unprocessable_entity
             end
     end
 
     def destroy
-        @like = Like.find_by(user_id: current_user&.id, post_id:params[:id])
-        @like.destroy
+        # NOTE: 保守性を考慮してdestoy_byではなくfind_byとdestoryを組み合わせる
+        @like = Like.find_by(user_id: current_user&.id, post_id: params[:id])
+        if @like
+            @like.destroy
+            head :no_content
+        else
+            head :not_found
+        end
     end
 
     private 

--- a/api/app/controllers/api/v1/likes_controller.rb
+++ b/api/app/controllers/api/v1/likes_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::LikesController < ApplicationController
+
+    def create
+        @like = current_user.likes.build(like_params)
+            if  @like.save
+                render json: @like
+            else
+                render json: @like.errors, status: 422
+            end
+    end
+
+    def destroy
+        @like = Like.find_by(user_id: current_user&.id, post_id:params[:id])
+        @like.destroy
+    end
+
+    private 
+    def like_params
+        params.require(:like).permit(:post_id)
+    end
+
+end

--- a/api/app/controllers/api/v1/posts_controller.rb
+++ b/api/app/controllers/api/v1/posts_controller.rb
@@ -63,7 +63,7 @@ class Api::V1::PostsController < ApplicationController
     def liked_posts
         user_liked_posts = Post.joins(:likes).where(likes: { user_id: current_user&.id })
         if user_liked_posts.any?
-            render json: liked_posts.as_json(methods: [:formatted_created_at, :formatted_updated_at])
+            render json: user_liked_posts.as_json(methods: [:formatted_created_at, :formatted_updated_at])
         else
             render json: []
         end

--- a/api/app/controllers/api/v1/posts_controller.rb
+++ b/api/app/controllers/api/v1/posts_controller.rb
@@ -11,13 +11,19 @@ class Api::V1::PostsController < ApplicationController
             if @post.save
                 render json: @post
             else
-                render json: @post.erros, status: 422
+                render json: @post.errors, status: 422
             end
     end
 
     def show
         is_current_user_post_owner = current_user&.id == @post.user_id
-        render json: @post.as_json(methods: [:formatted_created_at, :formatted_updated_at]).merge(is_current_user_post_owner: is_current_user_post_owner)
+        # current_userが@postに対していいねしているかどうかの判定
+        is_liked = Like.exists?(user_id: current_user&.id, post_id: @post.id)
+
+        render json: @post.as_json(methods: [:formatted_created_at, :formatted_updated_at]).merge(
+            is_current_user_post_owner: is_current_user_post_owner,
+            is_liked: is_liked
+            )
     end
 
     def update
@@ -54,6 +60,14 @@ class Api::V1::PostsController < ApplicationController
         render json: searched_posts.as_json(include: { user: { only: [:id, :name, :image] } },methods: :formatted_created_at)
     end
 
+    def liked_posts
+        liked_posts = Post.joins(:likes).where(likes: { user_id: current_user&.id })
+        if liked_posts&.any?
+            render json: liked_posts.as_json(methods: [:formatted_created_at, :formatted_updated_at])
+        else
+            render json: [], status: :not_found
+        end
+    end
 
     private 
     def post_params

--- a/api/app/controllers/api/v1/posts_controller.rb
+++ b/api/app/controllers/api/v1/posts_controller.rb
@@ -61,11 +61,11 @@ class Api::V1::PostsController < ApplicationController
     end
 
     def liked_posts
-        liked_posts = Post.joins(:likes).where(likes: { user_id: current_user&.id })
-        if liked_posts&.any?
+        user_liked_posts = Post.joins(:likes).where(likes: { user_id: current_user&.id })
+        if user_liked_posts.any?
             render json: liked_posts.as_json(methods: [:formatted_created_at, :formatted_updated_at])
         else
-            render json: [], status: :not_found
+            render json: []
         end
     end
 

--- a/api/app/models/like.rb
+++ b/api/app/models/like.rb
@@ -1,0 +1,4 @@
+class Like < ApplicationRecord
+    belongs_to :user
+    belongs_to :post
+end

--- a/api/app/models/post.rb
+++ b/api/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
   belongs_to :user
+  has_many :likes, dependent: :destroy
   default_scope -> { order('created_at DESC') }
 
   def formatted_created_at

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ActiveRecord::Base
          :recoverable, :validatable
   include DeviseTokenAuth::Concerns::User
   has_many :posts, dependent: :destroy
+  has_many :likes, dependent: :destroy
   has_one_attached :icon
   enum status: { inactive: 0, active: 1 }
 end

--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -62,5 +62,5 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
-  config.log_tags = [ :uuid ]
+  config.log_tags = [ :request_id ]
 end

--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -62,4 +62,5 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  config.log_tags = [ :uuid ]
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -77,10 +77,13 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :posts do
         get 'own_posts', on: :collection
+        get 'liked_posts', on: :collection     
         get 'search', on: :collection
       end
       resources :users, only: [:update] do
         get 'show_current_user', on: :collection     
+      end
+      resources :likes, only: [:create, :destroy] do
       end
     end
   end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -34,6 +34,7 @@
 #                                          POST   /api/auth(.:format)                                                                               devise_token_auth/registrations#create
 #                  api_auth_validate_token GET    /api/auth/validate_token(.:format)                                                                devise_token_auth/token_validations#validate_token
 #                   own_posts_api_v1_posts GET    /api/v1/posts/own_posts(.:format)                                                                 api/v1/posts#own_posts
+#                 liked_posts_api_v1_posts GET    /api/v1/posts/liked_posts(.:format)                                                               api/v1/posts#liked_posts
 #                      search_api_v1_posts GET    /api/v1/posts/search(.:format)                                                                    api/v1/posts#search
 #                             api_v1_posts GET    /api/v1/posts(.:format)                                                                           api/v1/posts#index
 #                                          POST   /api/v1/posts(.:format)                                                                           api/v1/posts#create
@@ -44,6 +45,8 @@
 #           show_current_user_api_v1_users GET    /api/v1/users/show_current_user(.:format)                                                         api/v1/users#show_current_user
 #                              api_v1_user PATCH  /api/v1/users/:id(.:format)                                                                       api/v1/users#update
 #                                          PUT    /api/v1/users/:id(.:format)                                                                       api/v1/users#update
+#                             api_v1_likes POST   /api/v1/likes(.:format)                                                                           api/v1/likes#create
+#                              api_v1_like DELETE /api/v1/likes/:id(.:format)                                                                       api/v1/likes#destroy
 #            rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                           action_mailbox/ingresses/postmark/inbound_emails#create
 #               rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                              action_mailbox/ingresses/relay/inbound_emails#create
 #            rails_sendgrid_inbound_emails POST   /rails/action_mailbox/sendgrid/inbound_emails(.:format)                                           action_mailbox/ingresses/sendgrid/inbound_emails#create

--- a/api/db/migrate/20240407081529_create_likes.rb
+++ b/api/db/migrate/20240407081529_create_likes.rb
@@ -1,0 +1,11 @@
+class CreateLikes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :likes, [:user_id, :post_id], unique: true
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_23_082935) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_07_081529) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,6 +37,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_23_082935) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "likes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -77,5 +87,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_23_082935) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
 end

--- a/api/spec/factories/likes.rb
+++ b/api/spec/factories/likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+    factory :like do
+        association :user
+        association :post
+    end
+  end

--- a/api/spec/factories/posts.rb
+++ b/api/spec/factories/posts.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
     factory :post do
       title { "テストタイトル" }
       content { "rspecでテストをします" }
-      user
+      association :user
     end
   end

--- a/api/spec/factories/users.rb
+++ b/api/spec/factories/users.rb
@@ -4,5 +4,8 @@ FactoryBot.define do
       email { "yamada@example.com" }
       password { "password" }
       password_confirmation { "password" }
+      confirmation_token { "_wCQHqBrkthWiZ_FUznF" }
+      confirmed_at { Date.today }
+      confirmation_sent_at { Date.today }
     end
   end

--- a/api/spec/rails_helper.rb
+++ b/api/spec/rails_helper.rb
@@ -61,4 +61,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/api/spec/requests/likes_spec.rb
+++ b/api/spec/requests/likes_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Likes", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/api/spec/requests/likes_spec.rb
+++ b/api/spec/requests/likes_spec.rb
@@ -1,7 +1,53 @@
-require 'rails_helper'
-
 RSpec.describe "Likes", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+
+  let(:user) { create(:user) }
+  let(:my_post) { create(:post, user: user) }
+  let(:like) { create(:like, user: user, post: my_post) }
+
+  before do
+    # ユーザー認証のAPIを呼び出し
+    post '/api/auth/sign_in', params: { email: user.email, password: user.password }
+    # レスポンスから認証トークンを取得
+    @auth_token = response.headers['authorization']
   end
+
+  describe "いいねを付与する" do
+    context '有効なパラメータが渡ってきた場合' do  
+      it 'likeレコードの作成を行う' do
+        expect {
+          post api_v1_likes_path,
+               params: { like: { post_id: my_post.id } },
+               headers: { authorization: @auth_token }
+        }.to change(Like, :count).by(1)
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context '無効なパラメータが渡ってきた場合' do
+      it 'likeレコードの作成を行わない' do
+        expect {
+          post api_v1_likes_path, params: { like: { post_id: "文字列" } }, headers: { authorization: @auth_token }
+        }.not_to change(Like, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+  end
+
+  describe "いいねを解除する" do
+    context '対象の投稿が既にいいね済みの場合' do
+      it 'いいねを解除(いいねのレコードを削除する)' do
+        delete api_v1_like_path(like.post_id),headers: { authorization: @auth_token }
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context '対象の投稿がまだいいねされていない場合' do
+      it 'not_foundのみを返却する' do
+        delete api_v1_like_path(99999),headers: { authorization: @auth_token }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
 end

--- a/app/app/build/fontawesome.js
+++ b/app/app/build/fontawesome.js
@@ -7,6 +7,7 @@ const solid = [
   "faChevronRight",
   "faDownload",
   "faEdit",
+  "faHeart",
   "faUpload",
   "faUser",
   "faTag",

--- a/app/app/pages/index.vue
+++ b/app/app/pages/index.vue
@@ -7,7 +7,11 @@
     <div class="right">
       <div v-for="(i, index) in data" :key="index" class="content_box flex">
         <div class="content_left">
-          <p class="circle">写真</p>
+          <img
+            :src="i.user.icon_url ? i.user.icon_url : '/user_default.png'"
+            alt="写真"
+            class="circle"
+          />
         </div>
         <div class="content_right">
           <p class="post_user_name">@{{ i.user.name }}</p>

--- a/app/app/pages/post/_postId.vue
+++ b/app/app/pages/post/_postId.vue
@@ -83,6 +83,7 @@ export default {
         this.addLike();
       }
     },
+    //TODO:未ログイン状態でいいねを押すとログインがポップアップで求められるように調整が必要。
     async addLike() {
       try {
         await this.$axios.post("/api/v1/likes", {

--- a/app/app/pages/post/_postId.vue
+++ b/app/app/pages/post/_postId.vue
@@ -3,18 +3,26 @@
     <div class="wrapper_left">
       <ul>
         <li>
-          <div class="circle">
+          <div v-if="is_liked" class="circle">
+            <font-awesome-icon
+              :icon="['fas', 'heart']"
+              class="font-awesome-size liked_post"
+              @click="RemoveLike(post.id)"
+            />
+          </div>
+          <div v-else class="circle">
             <font-awesome-icon
               :icon="['far', 'heart']"
               class="font-awesome-size"
+              @click="addLike"
             />
           </div>
         </li>
         <li>
           <div class="fab-box">
             <nuxt-link
-              :to="`/post/${data.id}/edit`"
-              v-if="data.is_current_user_post_owner"
+              :to="`/post/${post.id}/edit`"
+              v-if="post.is_current_user_post_owner"
             >
               <font-awesome-icon
                 :icon="['fas', 'pen-to-square']"
@@ -32,17 +40,17 @@
         <div class="content_right">
           <p>@kenny</p>
           <p>
-            更新日:{{ data.formatted_updated_at }} 投稿日:{{
-              data.formatted_created_at
+            更新日:{{ post.formatted_updated_at }} 投稿日:{{
+              post.formatted_created_at
             }}
           </p>
         </div>
       </div>
-      <h1>{{ data.title }}</h1>
+      <h1>{{ post.title }}</h1>
       <span>タグ1</span>
       <div
         class="markdown markdown_wrapper"
-        v-html="$md.render(data.content)"
+        v-html="$md.render(post.content)"
       ></div>
     </div>
   </div>
@@ -50,14 +58,43 @@
 
 <script>
 export default {
+  data() {
+    return {
+      post: [],
+      is_liked: false,
+    };
+  },
   async asyncData({ params, $axios }) {
     const id = params.postId;
     const response = await $axios.get(
       `${process.env.baseUrl}/api/v1/posts/${id}`
     );
     return {
-      data: response.data,
+      post: response.data,
+      is_liked: response.data.is_liked,
     };
+  },
+  methods: {
+    async addLike() {
+      try {
+        await this.$axios.post("/api/v1/likes", {
+          like: {
+            post_id: this.post.id,
+          },
+        });
+        this.is_liked = true;
+      } catch (e) {
+        console.log(e);
+      }
+    },
+    async RemoveLike(id) {
+      try {
+        await this.$axios.delete(`/api/v1/likes/${id}`);
+        this.is_liked = false;
+      } catch (error) {
+        console.log(e);
+      }
+    },
   },
 };
 </script>
@@ -108,6 +145,10 @@ export default {
 
 .font-awesome-size {
   font-size: 1.3rem;
+}
+
+.liked_post {
+  color: red;
 }
 
 .fab-box {

--- a/app/app/pages/post/_postId.vue
+++ b/app/app/pages/post/_postId.vue
@@ -3,20 +3,20 @@
     <div class="wrapper_left">
       <ul>
         <li>
-          <div v-if="is_liked" class="circle">
-            <font-awesome-icon
-              :icon="['fas', 'heart']"
-              class="font-awesome-size liked_post"
-              @click="RemoveLike(post.id)"
-            />
-          </div>
-          <div v-else class="circle">
-            <font-awesome-icon
-              :icon="['far', 'heart']"
-              class="font-awesome-size"
-              @click="addLike"
-            />
-          </div>
+          <button @click="handleLike" class="like-button">
+            <div v-if="is_liked" class="circle">
+              <font-awesome-icon
+                :icon="['fas', 'heart']"
+                class="font-awesome-size liked_post"
+              />
+            </div>
+            <div v-else class="circle">
+              <font-awesome-icon
+                :icon="['far', 'heart']"
+                class="font-awesome-size"
+              />
+            </div>
+          </button>
         </li>
         <li>
           <div class="fab-box">
@@ -69,12 +69,20 @@ export default {
     const response = await $axios.get(
       `${process.env.baseUrl}/api/v1/posts/${id}`
     );
+    console.log(response);
     return {
       post: response.data,
       is_liked: response.data.is_liked,
     };
   },
   methods: {
+    handleLike() {
+      if (this.is_liked) {
+        this.removeLike(this.post.id);
+      } else {
+        this.addLike();
+      }
+    },
     async addLike() {
       try {
         await this.$axios.post("/api/v1/likes", {
@@ -87,11 +95,11 @@ export default {
         console.log(e);
       }
     },
-    async RemoveLike(id) {
+    async removeLike(id) {
       try {
         await this.$axios.delete(`/api/v1/likes/${id}`);
         this.is_liked = false;
-      } catch (error) {
+      } catch (e) {
         console.log(e);
       }
     },

--- a/app/app/pages/user/my-like.vue
+++ b/app/app/pages/user/my-like.vue
@@ -14,6 +14,7 @@
     <p>「いいね」をした投稿がありません</p>
   </div>
 </template>
+
 <script>
 export default {
   data() {

--- a/app/app/pages/user/my-like.vue
+++ b/app/app/pages/user/my-like.vue
@@ -1,11 +1,40 @@
 <template>
-  <div class="mypost_wrapper">
-    <p>投稿がありません</p>
+  <div v-if="posts.length" class="mypost_wrapper">
+    <div v-for="(i, index) in posts" :key="index" class="content_box1">
+      <p><font-awesome-icon :icon="['fas', 'tag']" />タグ</p>
+      <nuxt-link :to="`/post/${i.id}`">
+        <h3 class="post_title">
+          {{ i.title }}
+        </h3>
+      </nuxt-link>
+      <p class="post_date">{{ i.formatted_created_at }}</p>
+    </div>
+  </div>
+  <div v-else class="mypost_wrapper">
+    <p>「いいね」をした投稿がありません</p>
   </div>
 </template>
-
 <script>
-export default {};
+export default {
+  data() {
+    return {
+      posts: [],
+    };
+  },
+  mounted() {
+    this.fetchData();
+  },
+  methods: {
+    async fetchData() {
+      try {
+        const response = await this.$axios.get("api/v1/posts/liked_posts");
+        this.posts = response.data;
+      } catch (e) {
+        console.log(e);
+      }
+    },
+  },
+};
 </script>
 
 <style>


### PR DESCRIPTION
## [概要]

 - 記事詳細画面
    - 「♡」を押下すると「いいね」を付けた判定となりマークが塗りつぶされる。
    - 「いいね」済みの投稿に対して再度「♡」を押下すると判定が解除されて塗りつぶしも解除
- ダッシュボード
    - 「いいね」に切り替えると自分が「いいね」した記事が一覧で表示される。

- ログの出力にrequest_idが排出されるようにしました。

## [挙動動画]

https://github.com/Kenty-725/qiita-kenny/assets/116368383/46595a70-7b0e-439a-92d8-5b1db62dfc99

