### PR TITLE
投稿にタグ付けをできるようにする

### DIFF
--- a/api/app/controllers/api/v1/posts_controller.rb
+++ b/api/app/controllers/api/v1/posts_controller.rb
@@ -73,7 +73,8 @@ class Api::V1::PostsController < ApplicationController
 
     # 自身の投稿のみを取得する
     def own_posts
-        current_user_posts = current_user&.posts
+        current_user_posts = current_user&.posts.includes(:tags)
+
         if current_user_posts&.any?
             render json: current_user_posts.as_json(
                 methods: [:formatted_created_at, :formatted_updated_at],
@@ -157,7 +158,7 @@ class Api::V1::PostsController < ApplicationController
         existing_tags = Tag.where(tag_name: tags).index_by(&:tag_name)
         
         tags.each do |tag_name|
-            tag = existing_tags[tag_name] || Tag.create(tag_name: tag_name)
+            tag = existing_tags[tag_name] || Tag.create!(tag_name: tag_name)
             #NOTE:紐付けがされていないタグの紐付けを行う。
             post.tags << tag unless post.tags.exists?(tag_name: tag_name)
         end

--- a/api/app/controllers/api/v1/posts_controller.rb
+++ b/api/app/controllers/api/v1/posts_controller.rb
@@ -81,7 +81,7 @@ class Api::V1::PostsController < ApplicationController
                 include: { tags: { only: [:tag_name] } }
                 )
         else
-            render json: [], status: :not_found
+            render json: []
         end
     end
 
@@ -98,7 +98,7 @@ class Api::V1::PostsController < ApplicationController
     end
 
     def liked_posts
-        user_liked_posts = Post.joins(:likes).where(likes: { user_id: current_user&.id })
+        user_liked_posts = Post.joins(:likes).where(likes: { user_id: current_user&.id }).includes(:tags)
         if user_liked_posts.any?
             render json: user_liked_posts.as_json(
                 methods: [:formatted_created_at, :formatted_updated_at],
@@ -135,9 +135,9 @@ class Api::V1::PostsController < ApplicationController
         tags_to_add = new_tags - old_tags
         tags_to_remove = old_tags - new_tags
       
-        # 追加されるべきタグを追加
+        # NOTE:追加されるべきタグを追加
         add_tags(tags_to_add, post)
-        # 削除されるべきタグを削除
+        # NOTE:削除されるべきタグを削除
         tags_to_remove.each do |tag_name|
           tag = Tag.find_by(tag_name: tag_name)
           post.tags.delete(tag) if tag
@@ -159,7 +159,7 @@ class Api::V1::PostsController < ApplicationController
         
         tags.each do |tag_name|
             tag = existing_tags[tag_name] || Tag.create!(tag_name: tag_name)
-            #NOTE:紐付けがされていないタグの紐付けを行う。
+            # NOTE:紐付けがされていないタグの紐付けを行う。
             post.tags << tag unless post.tags.exists?(tag_name: tag_name)
         end
     end

--- a/api/app/controllers/api/v1/users_controller.rb
+++ b/api/app/controllers/api/v1/users_controller.rb
@@ -8,6 +8,14 @@ class Api::V1::UsersController < ApplicationController
     
       user_data = current_user.attributes
       user_data[:icon_url] = rails_blob_url(current_user.icon) if current_user.icon.attached?
+
+      # 自身の投稿数をカウントし、user_dataに追加
+      user_data[:posts_count] = current_user.posts.count
+
+      #自身が受け取ったいいね数をカウントし、user_dataに追加
+      received_likes_count = current_user.posts.joins(:likes).count
+      user_data[:received_likes_count] = received_likes_count
+
       render json: user_data
     end
     

--- a/api/app/controllers/api/v1/users_controller.rb
+++ b/api/app/controllers/api/v1/users_controller.rb
@@ -2,19 +2,16 @@ class Api::V1::UsersController < ApplicationController
 
     def show_current_user
       # NOTE:未認証であれば401エラーを返却する。
-      unless current_user
-        return head :unauthorized
-      end
+      return head :unauthorized unless current_user
     
       user_data = current_user.attributes
-      user_data[:icon_url] = rails_blob_url(current_user.icon) if current_user.icon.attached?
 
-      # 自身の投稿数をカウントし、user_dataに追加
-      user_data[:posts_count] = current_user.posts.count
-
-      #自身が受け取ったいいね数をカウントし、user_dataに追加
-      received_likes_count = current_user.posts.joins(:likes).count
-      user_data[:received_likes_count] = received_likes_count
+      # HACK:　将来的にposts_countとreceived_likes_countにcounter_cacheを利用したパフォーマンス改善を検討
+      user_data.merge!({
+        icon_url: current_user.icon.attached? ? rails_blob_url(current_user.icon) : nil,
+        posts_count: current_user.posts.count,
+        received_likes_count: current_user.posts.joins(:likes).count
+       })
 
       render json: user_data
     end

--- a/api/app/models/post.rb
+++ b/api/app/models/post.rb
@@ -1,6 +1,9 @@
 class Post < ApplicationRecord
   belongs_to :user
   has_many :likes, dependent: :destroy
+  has_many :post_tags, dependent: :destroy
+  has_many :tags, through: :post_tags
+  
   default_scope -> { order('created_at DESC') }
 
   def formatted_created_at

--- a/api/app/models/post_tag.rb
+++ b/api/app/models/post_tag.rb
@@ -1,0 +1,4 @@
+class PostTag < ApplicationRecord
+  belongs_to :post
+  belongs_to :tag
+end

--- a/api/app/models/tag.rb
+++ b/api/app/models/tag.rb
@@ -1,3 +1,4 @@
 class Tag < ApplicationRecord
     has_many :post_tags, dependent: :destroy
+    has_many :posts, through: :post_tags
 end

--- a/api/app/models/tag.rb
+++ b/api/app/models/tag.rb
@@ -1,0 +1,3 @@
+class Tag < ApplicationRecord
+    has_many :post_tags, dependent: :destroy
+end

--- a/api/db/migrate/20240413023956_create_tags.rb
+++ b/api/db/migrate/20240413023956_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tags do |t|
+      t.string :tag_name
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/migrate/20240413024920_create_post_tags.rb
+++ b/api/db/migrate/20240413024920_create_post_tags.rb
@@ -1,0 +1,11 @@
+class CreatePostTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :post_tags do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :post_tags, [:post_id, :tag_id], unique: true
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_07_081529) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_13_024920) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -49,6 +49,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_07_081529) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
+  create_table "post_tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id", "tag_id"], name: "index_post_tags_on_post_id_and_tag_id", unique: true
+    t.index ["post_id"], name: "index_post_tags_on_post_id"
+    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
+  end
+
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title"
     t.text "content"
@@ -56,6 +66,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_07_081529) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "tag_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -89,5 +105,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_07_081529) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
+  add_foreign_key "post_tags", "posts"
+  add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "users"
 end

--- a/app/app/pages/index.vue
+++ b/app/app/pages/index.vue
@@ -25,14 +25,16 @@
             <p>
               <span v-for="(t, index) in i.tags" :key="index">
                 <font-awesome-icon :icon="['fas', 'tag']" />
-                {{ t.tag_name + "," }}
+                {{ t.tag_name }}
               </span>
             </p>
           </template>
           <template v-else>
             <p><font-awesome-icon :icon="['fas', 'tag']" />タグなし</p>
           </template>
-          <p>いいね数</p>
+          <p>
+            <font-awesome-icon :icon="['fas', 'heart']" />{{ i.likes_count }}
+          </p>
         </div>
       </div>
     </div>

--- a/app/app/pages/index.vue
+++ b/app/app/pages/index.vue
@@ -21,7 +21,17 @@
               {{ i.title }}
             </h3>
           </nuxt-link>
-          <p><font-awesome-icon :icon="['fas', 'tag']" />タグ</p>
+          <template v-if="i.tags.length">
+            <p>
+              <span v-for="(t, index) in i.tags" :key="index">
+                <font-awesome-icon :icon="['fas', 'tag']" />
+                {{ t.tag_name + "," }}
+              </span>
+            </p>
+          </template>
+          <template v-else>
+            <p><font-awesome-icon :icon="['fas', 'tag']" />タグなし</p>
+          </template>
           <p>いいね数</p>
         </div>
       </div>
@@ -36,6 +46,7 @@ import $axios from "axios";
 export default Vue.extend({
   async asyncData() {
     const response = await $axios.get(`${process.env.baseUrl}/api/v1/posts`);
+    console.log(response.data);
     return {
       data: response.data,
     };

--- a/app/app/pages/index.vue
+++ b/app/app/pages/index.vue
@@ -48,7 +48,6 @@ import $axios from "axios";
 export default Vue.extend({
   async asyncData() {
     const response = await $axios.get(`${process.env.baseUrl}/api/v1/posts`);
-    console.log(response.data);
     return {
       data: response.data,
     };

--- a/app/app/pages/post/_id/edit.vue
+++ b/app/app/pages/post/_id/edit.vue
@@ -16,6 +16,8 @@
             <input
               type="text"
               placeholder="タグを入力してください。スペース区切りで入力できます。"
+              v-model="inputTag"
+              @change="addTags"
             />
           </li>
           <li>
@@ -56,6 +58,8 @@ export default {
     return {
       title: "",
       content: "",
+      tags: [],
+      inputTag: "",
       showModal: false,
     };
   },
@@ -71,15 +75,46 @@ export default {
       id: response.data.id,
       title: response.data.title,
       content: response.data.content,
+      inputTag: response.data.tags.map((tag) => tag.tag_name).join(", "),
     };
   },
   methods: {
+    addTags() {
+      // カンマでタグを分割し、空白を削除して新しいタグの配列を生成する
+      const newTags = this.inputTag
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter((tag) => tag.length > 0); // 空のタグを除外
+
+      // 既存のタグ配列から、もはや含まれていないタグを削除し、
+      // 新規に追加されたタグのみを追加する
+      const updatedTags = this.tags.slice();
+      // ユーザーが削除したタグを`updatedTags`から削除する
+      this.tags.forEach((tag) => {
+        if (!newTags.includes(tag)) {
+          const index = updatedTags.indexOf(tag);
+          if (index > -1) {
+            updatedTags.splice(index, 1);
+          }
+        }
+      });
+      // 新しく追加されたタグを`updatedTags`に追加する
+      newTags.forEach((tag) => {
+        if (!this.tags.includes(tag)) {
+          updatedTags.push(tag);
+        }
+      });
+      // `this.tags`を更新したタグ配列で置き換える
+      this.tags = updatedTags;
+      console.log(this.tags);
+    },
     async editPost(id) {
       try {
         await this.$axios.put(`/api/v1/posts/${id}`, {
           post: {
             title: this.title,
             content: this.content,
+            tags: this.tags,
           },
         });
         this.$router.push(`/post/${id}`);

--- a/app/app/pages/post/_id/edit.vue
+++ b/app/app/pages/post/_id/edit.vue
@@ -15,7 +15,7 @@
           <li>
             <input
               type="text"
-              placeholder="タグを入力してください。スペース区切りで入力できます。"
+              placeholder="タグを入力してください。カンマ(,)区切りで入力できます。"
               v-model="inputTag"
               @change="addTags"
             />

--- a/app/app/pages/post/_id/edit.vue
+++ b/app/app/pages/post/_id/edit.vue
@@ -106,7 +106,6 @@ export default {
       });
       // `this.tags`を更新したタグ配列で置き換える
       this.tags = updatedTags;
-      console.log(this.tags);
     },
     async editPost(id) {
       try {

--- a/app/app/pages/post/_id/edit.vue
+++ b/app/app/pages/post/_id/edit.vue
@@ -84,28 +84,29 @@ export default {
       const newTags = this.inputTag
         .split(",")
         .map((tag) => tag.trim())
-        .filter((tag) => tag.length > 0); // 空のタグを除外
+        .filter((tag) => tag.length > 0);
 
-      // 既存のタグ配列から、もはや含まれていないタグを削除し、
-      // 新規に追加されたタグのみを追加する
-      const updatedTags = this.tags.slice();
-      // ユーザーが削除したタグを`updatedTags`から削除する
-      this.tags.forEach((tag) => {
-        if (!newTags.includes(tag)) {
-          const index = updatedTags.indexOf(tag);
-          if (index > -1) {
-            updatedTags.splice(index, 1);
-          }
-        }
-      });
-      // 新しく追加されたタグを`updatedTags`に追加する
+      // Setを使用して、効率的に重複を避けながら既存タグと新規タグを比較する
+      const currentTagsSet = new Set(this.tags);
+      const newTagsSet = new Set(newTags);
+
+      // 新規タグで現在のタグセットを更新する
       newTags.forEach((tag) => {
-        if (!this.tags.includes(tag)) {
-          updatedTags.push(tag);
+        // 新規タグが既存のセットに含まれるかチェック
+        if (!currentTagsSet.has(tag)) {
+          currentTagsSet.add(tag);
         }
       });
+
+      this.tags.forEach((tag) => {
+        // 現在のタグが新規タグセットに含まれていない場合は削除
+        if (!newTagsSet.has(tag)) {
+          currentTagsSet.delete(tag);
+        }
+      });
+
       // `this.tags`を更新したタグ配列で置き換える
-      this.tags = updatedTags;
+      this.tags = Array.from(currentTagsSet);
     },
     async editPost(id) {
       try {

--- a/app/app/pages/post/_postId.vue
+++ b/app/app/pages/post/_postId.vue
@@ -47,7 +47,17 @@
         </div>
       </div>
       <h1>{{ post.title }}</h1>
-      <span>タグ1</span>
+      <template v-if="post.tags.length">
+        <p>
+          <span v-for="(t, index) in post.tags" :key="index">
+            <font-awesome-icon :icon="['fas', 'tag']" />
+            {{ t.tag_name + "," }}
+          </span>
+        </p>
+      </template>
+      <template v-else>
+        <p><font-awesome-icon :icon="['fas', 'tag']" />タグなし</p>
+      </template>
       <div
         class="markdown markdown_wrapper"
         v-html="$md.render(post.content)"

--- a/app/app/pages/post/_postId.vue
+++ b/app/app/pages/post/_postId.vue
@@ -79,7 +79,6 @@ export default {
     const response = await $axios.get(
       `${process.env.baseUrl}/api/v1/posts/${id}`
     );
-    console.log(response);
     return {
       post: response.data,
       is_liked: response.data.is_liked,

--- a/app/app/pages/post/index.vue
+++ b/app/app/pages/post/index.vue
@@ -9,6 +9,8 @@
           <input
             type="text"
             placeholder="タグを入力してください。スペース区切りで入力できます。"
+            v-model="inputTag"
+            @change="addTags"
           />
         </li>
         <li>
@@ -31,15 +33,46 @@ export default {
     return {
       title: "",
       content: "",
+      inputTag: "",
+      tags: [],
     };
   },
   methods: {
+    addTags() {
+      // カンマでタグを分割し、空白を削除して新しいタグの配列を生成する
+      const newTags = this.inputTag
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter((tag) => tag.length > 0); // 空のタグを除外
+
+      // 既存のタグ配列から、もはや含まれていないタグを削除し、
+      // 新規に追加されたタグのみを追加する
+      const updatedTags = this.tags.slice();
+      // ユーザーが削除したタグを`updatedTags`から削除する
+      this.tags.forEach((tag) => {
+        if (!newTags.includes(tag)) {
+          const index = updatedTags.indexOf(tag);
+          if (index > -1) {
+            updatedTags.splice(index, 1);
+          }
+        }
+      });
+      // 新しく追加されたタグを`updatedTags`に追加する
+      newTags.forEach((tag) => {
+        if (!this.tags.includes(tag)) {
+          updatedTags.push(tag);
+        }
+      });
+      // `this.tags`を更新したタグ配列で置き換える
+      this.tags = updatedTags;
+    },
     async newPost() {
       try {
         await this.$axios.post("/api/v1/posts", {
           post: {
             title: this.title,
             content: this.content,
+            tags: this.tags,
           },
         });
         this.$router.push("/");

--- a/app/app/pages/post/index.vue
+++ b/app/app/pages/post/index.vue
@@ -43,28 +43,30 @@ export default {
       const newTags = this.inputTag
         .split(",")
         .map((tag) => tag.trim())
-        .filter((tag) => tag.length > 0); // 空のタグを除外
+        .filter((tag) => tag.length > 0);
 
-      // 既存のタグ配列から、もはや含まれていないタグを削除し、
-      // 新規に追加されたタグのみを追加する
-      const updatedTags = this.tags.slice();
-      // ユーザーが削除したタグを`updatedTags`から削除する
-      this.tags.forEach((tag) => {
-        if (!newTags.includes(tag)) {
-          const index = updatedTags.indexOf(tag);
-          if (index > -1) {
-            updatedTags.splice(index, 1);
-          }
-        }
-      });
-      // 新しく追加されたタグを`updatedTags`に追加する
+      // Setを使用して、効率的に重複を避けながら既存タグと新規タグを比較する
+      const currentTagsSet = new Set(this.tags);
+      const newTagsSet = new Set(newTags);
+
+      // 新規タグで現在のタグセットを更新する
       newTags.forEach((tag) => {
-        if (!this.tags.includes(tag)) {
-          updatedTags.push(tag);
+        // 新規タグが既存のセットに含まれるかチェック
+        if (!currentTagsSet.has(tag)) {
+          // 含まれていなければ追加
+          currentTagsSet.add(tag);
         }
       });
+
+      this.tags.forEach((tag) => {
+        // 現在のタグが新規タグセットに含まれていない場合は削除
+        if (!newTagsSet.has(tag)) {
+          currentTagsSet.delete(tag);
+        }
+      });
+
       // `this.tags`を更新したタグ配列で置き換える
-      this.tags = updatedTags;
+      this.tags = Array.from(currentTagsSet);
     },
     async newPost() {
       try {

--- a/app/app/pages/post/index.vue
+++ b/app/app/pages/post/index.vue
@@ -8,7 +8,7 @@
         <li>
           <input
             type="text"
-            placeholder="タグを入力してください。スペース区切りで入力できます。"
+            placeholder="タグを入力してください。カンマ(,)区切りで入力できます。"
             v-model="inputTag"
             @change="addTags"
           />

--- a/app/app/pages/user/index.vue
+++ b/app/app/pages/user/index.vue
@@ -10,11 +10,11 @@
         <p class="user_name">@{{ user.name }}</p>
         <div class="count_box">
           <div class="post_count_box">
-            <p>1</p>
+            <p>{{ user.posts_count }}</p>
             <p>投稿</p>
           </div>
           <div class="like_count_box">
-            <p>1</p>
+            <p>{{ user.received_likes_count }}</p>
             <p>いいね</p>
           </div>
         </div>

--- a/app/app/pages/user/my-like.vue
+++ b/app/app/pages/user/my-like.vue
@@ -1,7 +1,17 @@
 <template>
   <div v-if="posts.length" class="mypost_wrapper">
     <div v-for="(i, index) in posts" :key="index" class="content_box1">
-      <p><font-awesome-icon :icon="['fas', 'tag']" />タグ</p>
+      <template v-if="i.tags.length">
+        <p>
+          <span v-for="(t, index) in i.tags" :key="index">
+            <font-awesome-icon :icon="['fas', 'tag']" />
+            {{ t.tag_name }}
+          </span>
+        </p>
+      </template>
+      <template v-else>
+        <p><font-awesome-icon :icon="['fas', 'tag']" />タグなし</p>
+      </template>
       <nuxt-link :to="`/post/${i.id}`">
         <h3 class="post_title">
           {{ i.title }}

--- a/app/app/pages/user/my-post.vue
+++ b/app/app/pages/user/my-post.vue
@@ -39,7 +39,6 @@ export default {
       try {
         const response = await this.$axios.get("api/v1/posts/own_posts");
         this.posts = response.data;
-        console.log(this.posts);
       } catch (e) {
         console.log(e);
       }

--- a/app/app/pages/user/my-post.vue
+++ b/app/app/pages/user/my-post.vue
@@ -1,7 +1,17 @@
 <template>
   <div v-if="posts.length" class="mypost_wrapper">
     <div v-for="(i, index) in posts" :key="index" class="content_box1">
-      <p><font-awesome-icon :icon="['fas', 'tag']" />タグ</p>
+      <template v-if="i.tags.length">
+        <p>
+          <span v-for="(t, index) in i.tags" :key="index">
+            <font-awesome-icon :icon="['fas', 'tag']" />
+            {{ t.tag_name }}
+          </span>
+        </p>
+      </template>
+      <template v-else>
+        <p><font-awesome-icon :icon="['fas', 'tag']" />タグなし</p>
+      </template>
       <nuxt-link :to="`/post/${i.id}`">
         <h3 class="post_title">
           {{ i.title }}
@@ -29,6 +39,7 @@ export default {
       try {
         const response = await this.$axios.get("api/v1/posts/own_posts");
         this.posts = response.data;
+        console.log(this.posts);
       } catch (e) {
         console.log(e);
       }


### PR DESCRIPTION
## [概要]

- 記事投稿作成時及び更新時にタグ付けできるようにしました。
  - カンマ(,)区切りで入力された値がタグと認識されます。 
  - 記事一覧や詳細画面でタグが表示できるようにしました。

- その他変更点
  - 記事一覧にていいね数を表示するようにしました。　 
  - ダッシュボードで下記２点を表示できるようにしました
    - ログインユーザーの投稿数
    - ログインユーザーが獲得した総いいね数  

※テストは別途テストケースを記載して行います。
## [挙動動画]

https://github.com/Kenty-725/qiita-kenny/assets/116368383/466bbabd-5b3b-4a2d-8959-1f1728f8eee6

