### PR TITLE
タグに紐づく記事の一覧取得

### DIFF
--- a/api/app/controllers/api/v1/posts_controller.rb
+++ b/api/app/controllers/api/v1/posts_controller.rb
@@ -3,9 +3,8 @@ class Api::V1::PostsController < ApplicationController
     
     def index
         posts = Post.page(page_number).includes(:user, :tags, :likes)
-        response = response_posts_data(posts, posts.total_pages, need_user_data: true)
 
-        render json: response
+        render json: response_posts_data(posts, posts.total_pages, need_user_data: true)
     end
 
     def create
@@ -64,9 +63,7 @@ class Api::V1::PostsController < ApplicationController
         current_user_posts = current_user&.posts.page(page_number).includes(:tags)
 
         if current_user_posts&.any?
-            response = response_posts_data(current_user_posts, current_user_posts.total_pages)
-
-            render json: response
+            render json: response_posts_data(current_user_posts, current_user_posts.total_pages)
         else
             render json: []
         end
@@ -79,19 +76,15 @@ class Api::V1::PostsController < ApplicationController
                          else  
                             Post.all
                          end
-        
         searched_posts = searched_posts.page(page_number).includes(:user)
-        response = response_posts_data(searched_posts, searched_posts.total_pages, need_user_data: true)
 
-        render json: response
+        render json: response_posts_data(searched_posts, searched_posts.total_pages, need_user_data: true)
     end
 
     def liked_posts
         user_liked_posts = Post.joins(:likes).where(likes: { user_id: current_user&.id }).page(page_number).includes(:tags)
         if user_liked_posts.any?
-            response = response_posts_data(user_liked_posts, user_liked_posts.total_pages)
-
-            render json: response
+            render json: response_posts_data(user_liked_posts, user_liked_posts.total_pages)
         else
             render json: []
         end
@@ -169,7 +162,7 @@ class Api::V1::PostsController < ApplicationController
 
     def page_number
         #NOTE:ページネーション判定に必要なpage番号の確認を行う。
-        page_number = params[:page] || 1
+        page_number = params[:page].to_i || 1
     end
 
     #HACK:共通したrenderの処理を書く

--- a/api/app/controllers/api/v1/posts_controller.rb
+++ b/api/app/controllers/api/v1/posts_controller.rb
@@ -98,11 +98,11 @@ class Api::V1::PostsController < ApplicationController
     end
 
     def list_posts_by_tag
-        tag_data = Tag.where(id: params[:id])
+        tag_data = Tag.find_by(id: params[:id]) 
         tag_related_posts = Post.joins(:tags).where(tags: {id: params[:id]}).page(page_number).includes(:likes, :user)
 
         if tag_related_posts.any?
-            response = response_posts_data(tag_related_posts, tag_related_posts.total_pages, tag_related_posts.size, need_user_data: true)
+            response = response_posts_data(tag_related_posts, tag_related_posts.total_pages, tag_related_posts.total_count, need_user_data: true)
             #　NOTE:タグの情報も必要なのでresponseに追加する。
             response[:tag] = tag_data
 

--- a/api/app/models/post.rb
+++ b/api/app/models/post.rb
@@ -4,7 +4,8 @@ class Post < ApplicationRecord
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags
   
-  default_scope -> { order('created_at DESC') }
+  #TODO: デフォルトでorderを効かせるのはバグの温床になりかねないので要検討が必要
+  default_scope -> { order('posts.created_at DESC') }
   paginates_per 5  # 1ページあたり10項目をデフォルトに設定
 
   def formatted_created_at

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -35,6 +35,7 @@
 #                  api_auth_validate_token GET    /api/auth/validate_token(.:format)                                                                devise_token_auth/token_validations#validate_token
 #                   own_posts_api_v1_posts GET    /api/v1/posts/own_posts(.:format)                                                                 api/v1/posts#own_posts
 #                 liked_posts_api_v1_posts GET    /api/v1/posts/liked_posts(.:format)                                                               api/v1/posts#liked_posts
+#            list_posts_by_tag_api_v1_post GET    /api/v1/posts/:id/list_posts_by_tag(.:format)                                                     api/v1/posts#list_posts_by_tag
 #                      search_api_v1_posts GET    /api/v1/posts/search(.:format)                                                                    api/v1/posts#search
 #                             api_v1_posts GET    /api/v1/posts(.:format)                                                                           api/v1/posts#index
 #                                          POST   /api/v1/posts(.:format)                                                                           api/v1/posts#create
@@ -82,6 +83,7 @@ Rails.application.routes.draw do
         get 'own_posts', on: :collection
         get 'liked_posts', on: :collection     
         get 'search', on: :collection
+        get 'list_posts_by_tag', on: :member
       end
       resources :users, only: [:update] do
         get 'show_current_user', on: :collection     

--- a/app/app/components/PostList.vue
+++ b/app/app/components/PostList.vue
@@ -1,0 +1,90 @@
+<template>
+  <div>
+    <div v-for="(post, index) in posts" :key="index" class="content_box flex">
+      <div class="content_left">
+        <img
+          :src="post.user.icon_url ? post.user.icon_url : '/user_default.png'"
+          alt="写真"
+          class="circle"
+        />
+      </div>
+      <div class="content_right">
+        <p class="post_user_name">@{{ post.user.name }}</p>
+        <time class="post_date">{{ post.formatted_created_at }}</time>
+        <nuxt-link :to="`/post/${post.id}`">
+          <h3 class="post_title">
+            {{ post.title }}
+          </h3>
+        </nuxt-link>
+        <template v-if="post.tags.length">
+          <p>
+            <span v-for="(t, index) in post.tags" :key="index">
+              <font-awesome-icon :icon="['fas', 'tag']" />
+              <nuxt-link :to="`/tag/${t.id}`">{{ t.tag_name }}</nuxt-link>
+            </span>
+          </p>
+        </template>
+        <template v-else>
+          <p><font-awesome-icon :icon="['fas', 'tag']" />タグなし</p>
+        </template>
+        <p>
+          <font-awesome-icon :icon="['fas', 'heart']" />{{ post.likes_count }}
+        </p>
+      </div>
+    </div>
+    <v-pagination
+      v-model="currentPage"
+      :length="totalPages"
+      @input="changePage"
+    ></v-pagination>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    posts: Array,
+    totalPages: Number,
+    currentPage: {
+      type: Number,
+      default: 1,
+    },
+  },
+  methods: {
+    changePage() {
+      // 親コンポーネントへイベントを発信
+      this.$emit("page-changed", this.currentPage);
+    },
+  },
+};
+</script>
+
+<style>
+.flex {
+  display: flex;
+}
+
+.content_left {
+  margin: 0 15px;
+}
+
+.content_box {
+  border-radius: 10px;
+  background-color: #ffffff;
+  margin-bottom: 5px;
+  padding: 5px 8px;
+}
+
+.content_right p {
+  margin: 0;
+}
+
+.post_date {
+  color: #9b9999;
+}
+
+.post_title {
+  font-size: 1.3rem;
+  font-weight: 400;
+}
+</style>

--- a/app/app/components/PostList.vue
+++ b/app/app/components/PostList.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-for="(post, index) in posts" :key="index" class="content_box flex">
+    <div v-for="post in posts" :key="post.id" class="content_box flex">
       <div class="content_left">
         <img
           :src="post.user.icon_url ? post.user.icon_url : '/user_default.png'"
@@ -18,7 +18,7 @@
         </nuxt-link>
         <template v-if="post.tags.length">
           <p>
-            <span v-for="(t, index) in post.tags" :key="index">
+            <span v-for="t in post.tags" :key="t.id">
               <font-awesome-icon :icon="['fas', 'tag']" />
               <nuxt-link :to="`/tag/${t.id}`">{{ t.tag_name }}</nuxt-link>
             </span>
@@ -40,7 +40,7 @@
   </div>
 </template>
 
-<script>
+<script scoped>
 export default {
   props: {
     posts: Array,

--- a/app/app/pages/index.vue
+++ b/app/app/pages/index.vue
@@ -5,43 +5,12 @@
       <div class="user_lanking">ここにリストが表示される</div>
     </div>
     <div class="right">
-      <div v-for="(i, index) in posts" :key="index" class="content_box flex">
-        <div class="content_left">
-          <img
-            :src="i.user.icon_url ? i.user.icon_url : '/user_default.png'"
-            alt="写真"
-            class="circle"
-          />
-        </div>
-        <div class="content_right">
-          <p class="post_user_name">@{{ i.user.name }}</p>
-          <time class="post_date">{{ i.formatted_created_at }}</time>
-          <nuxt-link :to="`/post/${i.id}`">
-            <h3 class="post_title">
-              {{ i.title }}
-            </h3>
-          </nuxt-link>
-          <template v-if="i.tags.length">
-            <p>
-              <span v-for="(t, index) in i.tags" :key="index">
-                <font-awesome-icon :icon="['fas', 'tag']" />
-                <nuxt-link :to="`/tag/${t.id}`">{{ t.tag_name }}</nuxt-link>
-              </span>
-            </p>
-          </template>
-          <template v-else>
-            <p><font-awesome-icon :icon="['fas', 'tag']" />タグなし</p>
-          </template>
-          <p>
-            <font-awesome-icon :icon="['fas', 'heart']" />{{ i.likes_count }}
-          </p>
-        </div>
-      </div>
-      <v-pagination
-        v-model="currentPage"
-        :length="totalPages"
-        @input="changePage"
-      ></v-pagination>
+      <PostList
+        :posts="posts"
+        :totalPages="totalPages"
+        :currentPage="currentPage"
+        @page-changed="changePage"
+      />
     </div>
   </div>
 </template>
@@ -66,13 +35,14 @@ export default Vue.extend({
     };
   },
   methods: {
-    async changePage() {
+    async changePage(page) {
       const response = await $axios.get(
-        `${process.env.baseUrl}/api/v1/posts?page=${this.currentPage}`
+        `${process.env.baseUrl}/api/v1/posts?page=${page}`
       );
 
       this.posts = response.data.posts;
       this.totalPages = response.data.total_pages;
+      this.currentPage = page;
     },
   },
 });
@@ -85,10 +55,6 @@ export default Vue.extend({
   padding: 15px;
 }
 
-.flex {
-  display: flex;
-}
-
 .left {
   flex: 1;
 }
@@ -97,35 +63,11 @@ export default Vue.extend({
   flex: 1.5;
 }
 
-.content_left {
-  margin: 0 15px;
-}
-
-.content_box {
-  border-radius: 10px;
-  background-color: #ffffff;
-  margin-bottom: 5px;
-  padding: 5px 8px;
-}
-
 .user_lanking {
   border: 1px solid black;
   width: 80%;
   margin: 0 auto;
   height: 60vh;
   text-align: center;
-}
-
-.content_right p {
-  margin: 0;
-}
-
-.post_date {
-  color: #9b9999;
-}
-
-.post_title {
-  font-size: 1.3rem;
-  font-weight: 400;
 }
 </style>

--- a/app/app/pages/post/_postId.vue
+++ b/app/app/pages/post/_postId.vue
@@ -49,7 +49,7 @@
       <h1>{{ post.title }}</h1>
       <template v-if="post.tags.length">
         <p>
-          <span v-for="(t, index) in post.tags" :key="index">
+          <span v-for="t in post.tags" :key="t.id">
             <font-awesome-icon :icon="['fas', 'tag']" />
             {{ t.tag_name + "," }}
           </span>

--- a/app/app/pages/search.vue
+++ b/app/app/pages/search.vue
@@ -16,7 +16,11 @@
         class="serch_result_content flex"
       >
         <div class="content_left">
-          <p class="circle">写真</p>
+          <img
+            :src="post.user.icon_url ? post.user.icon_url : '/user_default.png'"
+            alt="写真"
+            class="circle"
+          />
         </div>
         <div class="content_right">
           <p class="post_user_name">@{{ post.user.name }}</p>
@@ -27,8 +31,20 @@
               v-html="highlightKeyword(post.title, keyword)"
             ></h3>
           </nuxt-link>
-          <p><font-awesome-icon :icon="['fas', 'tag']" />タグ</p>
-          <p>いいね数</p>
+          <template v-if="post.tags.length">
+            <p>
+              <span v-for="(t, index) in post.tags" :key="index">
+                <font-awesome-icon :icon="['fas', 'tag']" />
+                <nuxt-link :to="`/tag/${t.id}`">{{ t.tag_name }}</nuxt-link>
+              </span>
+            </p>
+          </template>
+          <template v-else>
+            <p><font-awesome-icon :icon="['fas', 'tag']" />タグなし</p>
+          </template>
+          <p>
+            <font-awesome-icon :icon="['fas', 'heart']" />{{ post.likes_count }}
+          </p>
         </div>
       </div>
       <v-pagination

--- a/app/app/pages/search.vue
+++ b/app/app/pages/search.vue
@@ -33,7 +33,7 @@
           </nuxt-link>
           <template v-if="post.tags.length">
             <p>
-              <span v-for="(t, index) in post.tags" :key="index">
+              <span v-for="t in post.tags" :key="t.id">
                 <font-awesome-icon :icon="['fas', 'tag']" />
                 <nuxt-link :to="`/tag/${t.id}`">{{ t.tag_name }}</nuxt-link>
               </span>

--- a/app/app/pages/tag/_tagid.vue
+++ b/app/app/pages/tag/_tagid.vue
@@ -11,43 +11,12 @@
       <div class="user_lanking">ユーザーランキング</div>
     </div>
     <div class="right">
-      <div v-for="(i, index) in posts" :key="index" class="content_box flex">
-        <div class="content_left">
-          <img
-            :src="i.user.icon_url ? i.user.icon_url : '/user_default.png'"
-            alt="写真"
-            class="circle"
-          />
-        </div>
-        <div class="content_right">
-          <p class="post_user_name">@{{ i.user.name }}</p>
-          <time class="post_date">{{ i.formatted_created_at }}</time>
-          <nuxt-link :to="`/post/${i.id}`">
-            <h3 class="post_title">
-              {{ i.title }}
-            </h3>
-          </nuxt-link>
-          <template v-if="i.tags.length">
-            <p>
-              <span v-for="(t, index) in i.tags" :key="index">
-                <font-awesome-icon :icon="['fas', 'tag']" />
-                <nuxt-link :to="`/tag/${t.id}`">{{ t.tag_name }}</nuxt-link>
-              </span>
-            </p>
-          </template>
-          <template v-else>
-            <p><font-awesome-icon :icon="['fas', 'tag']" />タグなし</p>
-          </template>
-          <p>
-            <font-awesome-icon :icon="['fas', 'heart']" />{{ i.likes_count }}
-          </p>
-        </div>
-      </div>
-      <v-pagination
-        v-model="currentPage"
-        :length="totalPages"
-        @input="changePage"
-      ></v-pagination>
+      <PostList
+        :posts="posts"
+        :totalPages="totalPages"
+        :currentPage="currentPage"
+        @page-changed="changePage"
+      />
     </div>
   </div>
 </template>
@@ -56,6 +25,7 @@
 export default {
   data() {
     return {
+      id: null,
       currentPage: 1,
       totalPages: 0,
       total_count: 0,
@@ -64,19 +34,33 @@ export default {
     };
   },
   async asyncData({ params, $axios }) {
-    console.log(params);
     const id = params.tagid;
-    console.log(id);
     const response = await $axios.get(
       `${process.env.baseUrl}/api/v1/posts/${id}/list_posts_by_tag`
     );
-    console.log(response);
     return {
+      id: id,
       posts: response.data.posts,
-      tag: response.data.tag[0],
+      tag: response.data.tag,
       total_count: response.data.total_count,
       totalPages: response.data.total_pages,
     };
+  },
+  methods: {
+    async changePage(page) {
+      const response = await this.$axios.get(
+        `${process.env.baseUrl}/api/v1/posts/${this.id}/list_posts_by_tag`,
+        {
+          params: {
+            page: page,
+          },
+        }
+      );
+      this.posts = response.data.posts;
+      this.tag = response.data.tag;
+      this.totalPages = response.data.total_pages;
+      this.currentPage = page;
+    },
   },
 };
 </script>

--- a/app/app/pages/tag/_tagid.vue
+++ b/app/app/pages/tag/_tagid.vue
@@ -1,8 +1,14 @@
 <template>
   <div class="home_wrapper">
     <div class="left">
-      <p>ユーザーランキング</p>
-      <div class="user_lanking">ここにリストが表示される</div>
+      <div class="tag_box">
+        <h1>{{ tag.tag_name }}</h1>
+        <div class="tag_post_count">
+          <p>{{ total_count }}</p>
+          <p>記事</p>
+        </div>
+      </div>
+      <div class="user_lanking">ユーザーランキング</div>
     </div>
     <div class="right">
       <div v-for="(i, index) in posts" :key="index" class="content_box flex">
@@ -47,85 +53,51 @@
 </template>
 
 <script>
-import Vue from "vue";
-import $axios from "axios";
-
-export default Vue.extend({
+export default {
   data() {
     return {
       currentPage: 1,
       totalPages: 0,
+      total_count: 0,
+      tag: [],
       posts: [],
     };
   },
-  async asyncData() {
-    const response = await $axios.get(`${process.env.baseUrl}/api/v1/posts`);
+  async asyncData({ params, $axios }) {
+    console.log(params);
+    const id = params.tagid;
+    console.log(id);
+    const response = await $axios.get(
+      `${process.env.baseUrl}/api/v1/posts/${id}/list_posts_by_tag`
+    );
+    console.log(response);
     return {
       posts: response.data.posts,
+      tag: response.data.tag[0],
+      total_count: response.data.total_count,
       totalPages: response.data.total_pages,
     };
   },
-  methods: {
-    async changePage() {
-      const response = await $axios.get(
-        `${process.env.baseUrl}/api/v1/posts?page=${this.currentPage}`
-      );
-
-      this.posts = response.data.posts;
-      this.totalPages = response.data.total_pages;
-    },
-  },
-});
+};
 </script>
 
 <style>
-.home_wrapper {
-  display: flex;
-  height: auto;
-  padding: 15px;
-}
-
-.flex {
-  display: flex;
-}
-
-.left {
-  flex: 1;
-}
-
-.right {
-  flex: 1.5;
-}
-
-.content_left {
-  margin: 0 15px;
-}
-
-.content_box {
+.tag_box {
+  background-color: #fff;
   border-radius: 10px;
-  background-color: #ffffff;
-  margin-bottom: 5px;
-  padding: 5px 8px;
-}
-
-.user_lanking {
-  border: 1px solid black;
   width: 80%;
   margin: 0 auto;
-  height: 60vh;
   text-align: center;
+  margin-bottom: 30px;
 }
 
-.content_right p {
-  margin: 0;
+.tag_box > h1 {
+  border-bottom: 1px solid #828282;
+  font-size: 1.5rem;
+  padding: 10px 0;
 }
 
-.post_date {
-  color: #9b9999;
-}
-
-.post_title {
-  font-size: 1.3rem;
-  font-weight: 400;
+.tag_post_count {
+  font-size: 1.1rem;
 }
 </style>

--- a/app/app/pages/user/my-like.vue
+++ b/app/app/pages/user/my-like.vue
@@ -1,9 +1,9 @@
 <template>
   <div v-if="posts.length" class="mypost_wrapper">
-    <div v-for="(i, index) in posts" :key="index" class="content_box1">
-      <template v-if="i.tags.length">
+    <div v-for="post in posts" :key="post.id" class="content_box1">
+      <template v-if="post.tags.length">
         <p>
-          <span v-for="(t, index) in i.tags" :key="index">
+          <span v-for="t in post.tags" :key="t.id">
             <font-awesome-icon :icon="['fas', 'tag']" />
             <nuxt-link :to="`/tag/${t.id}`">{{ t.tag_name }}</nuxt-link>
           </span>
@@ -12,12 +12,12 @@
       <template v-else>
         <p><font-awesome-icon :icon="['fas', 'tag']" />タグなし</p>
       </template>
-      <nuxt-link :to="`/post/${i.id}`">
+      <nuxt-link :to="`/post/${post.id}`">
         <h3 class="post_title">
-          {{ i.title }}
+          {{ post.title }}
         </h3>
       </nuxt-link>
-      <p class="post_date">{{ i.formatted_created_at }}</p>
+      <p class="post_date">{{ post.formatted_created_at }}</p>
     </div>
     <v-pagination
       v-model="currentPage"

--- a/app/app/pages/user/my-like.vue
+++ b/app/app/pages/user/my-like.vue
@@ -5,7 +5,7 @@
         <p>
           <span v-for="(t, index) in i.tags" :key="index">
             <font-awesome-icon :icon="['fas', 'tag']" />
-            {{ t.tag_name }}
+            <nuxt-link :to="`/tag/${t.id}`">{{ t.tag_name }}</nuxt-link>
           </span>
         </p>
       </template>

--- a/app/app/pages/user/my-post.vue
+++ b/app/app/pages/user/my-post.vue
@@ -1,9 +1,9 @@
 <template>
   <div v-if="posts.length" class="mypost_wrapper">
-    <div v-for="(i, index) in posts" :key="index" class="content_box1">
-      <template v-if="i.tags.length">
+    <div v-for="post in posts" :key="post.id" class="content_box1">
+      <template v-if="post.tags.length">
         <p>
-          <span v-for="(t, index) in i.tags" :key="index">
+          <span v-for="t in post.tags" :key="t.id">
             <font-awesome-icon :icon="['fas', 'tag']" />
             <nuxt-link :to="`/tag/${t.id}`">{{ t.tag_name }}</nuxt-link>
           </span>
@@ -12,12 +12,12 @@
       <template v-else>
         <p><font-awesome-icon :icon="['fas', 'tag']" />タグなし</p>
       </template>
-      <nuxt-link :to="`/post/${i.id}`">
+      <nuxt-link :to="`/post/${post.id}`">
         <h3 class="post_title">
-          {{ i.title }}
+          {{ post.title }}
         </h3>
       </nuxt-link>
-      <p class="post_date">{{ i.formatted_created_at }}</p>
+      <p class="post_date">{{ post.formatted_created_at }}</p>
     </div>
     <v-pagination
       v-model="currentPage"

--- a/app/app/pages/user/my-post.vue
+++ b/app/app/pages/user/my-post.vue
@@ -5,7 +5,7 @@
         <p>
           <span v-for="(t, index) in i.tags" :key="index">
             <font-awesome-icon :icon="['fas', 'tag']" />
-            {{ t.tag_name }}
+            <nuxt-link :to="`/tag/${t.id}`">{{ t.tag_name }}</nuxt-link>
           </span>
         </p>
       </template>


### PR DESCRIPTION
## [概要]
- タグに紐づく記事の一覧情報を取得しました。
- 記事のタグからタグ一覧ページへ遷移可能になりました

## [挙動動画]

https://github.com/Kenty-725/qiita-kenny/assets/116368383/48437b3f-c2ae-4409-9b31-c9badda73673

